### PR TITLE
Buidler tasks for reading proposals

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,13 @@
     },
     "extends": "standard",
     "globals": {
-        "contract": "readonly"
+        "contract": "readonly",
+        "buidlerArguments": "readonly",
+        "artifacts": "readonly",
+        "web3": "readonly",
+        "task": "readonly",
+        "types": "readonly",
+        "config": "readonly"
     },
     "parserOptions": {
         "ecmaVersion": 2018

--- a/package-lock.json
+++ b/package-lock.json
@@ -1188,6 +1188,12 @@
         "wrap-ansi": "^2.0.0"
       }
     },
+    "clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "optional": true
+    },
     "clone-deep": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-1.0.0.tgz",
@@ -1320,6 +1326,14 @@
       "requires": {
         "ini": "^1.3.4",
         "proto-list": "~1.2.1"
+      }
+    },
+    "console.table": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/console.table/-/console.table-0.10.0.tgz",
+      "integrity": "sha1-CRcCVYiHW+/XDPLv9L7yxuLXXQQ=",
+      "requires": {
+        "easy-table": "1.1.0"
       }
     },
     "contains-path": {
@@ -1647,6 +1661,15 @@
       "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
       "dev": true
     },
+    "defaults": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
+      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "optional": true,
+      "requires": {
+        "clone": "^1.0.2"
+      }
+    },
     "defer-to-connect": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
@@ -1789,6 +1812,14 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "easy-table": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/easy-table/-/easy-table-1.1.0.tgz",
+      "integrity": "sha1-hvmrTBAvA3G3KXuSplHVgkvIy3M=",
+      "requires": {
+        "wcwidth": ">=1.0.1"
+      }
     },
     "ecc-jsbn": {
       "version": "0.1.2",
@@ -8165,6 +8196,15 @@
       "resolved": "https://registry.npmjs.org/warning-symbol/-/warning-symbol-0.1.0.tgz",
       "integrity": "sha1-uzHdEbeg+dZ6su2V9Fe2WCW7rSE=",
       "dev": true
+    },
+    "wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "optional": true,
+      "requires": {
+        "defaults": "^1.0.3"
+      }
     },
     "web3": {
       "version": "1.0.0-beta.37",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,15 @@
     "prompt-confirm": "^2.0.4",
     "solidity-coverage": "github:rotcivegaf/solidity-coverage#5875f5b7bc74d447f3312c9c0e9fc7814b482477",
     "standard": "^11.0.0",
-    "web3": "1.0.0-beta.37"
+    "web3": "1.0.0-beta.37",
+    "console.table": "^0.10.0"
   },
   "scripts": {
     "compile": "buidler compile",
     "test": "bash scripts/test.sh",
     "gcli": "ganache-cli -l 8000000 -m \"fetch local valve black attend double eye excite planet primary install allow\"",
     "lint:tests": "eslint test/*.js",
+    "lint:scripts": "eslint scripts/*.js",
     "coverage": "SOLIDITY_COVERAGE=true bash scripts/test.sh"
   },
   "repository": {

--- a/scripts/pool-tasks.js
+++ b/scripts/pool-tasks.js
@@ -24,7 +24,7 @@ task('pool-deploy', 'Deploys a new instance of the pool and activates it')
     }
 
     const token = await getApprovedToken()
-    if (token == undefined) {
+    if (token === undefined) {
       return
     }
 
@@ -110,7 +110,7 @@ task('pool-deposit', 'Donates tokens to the pool')
     }
 
     const token = await getApprovedToken()
-    if (token == undefined) {
+    if (token === undefined) {
       return
     }
 

--- a/scripts/proposal-utils.js
+++ b/scripts/proposal-utils.js
@@ -1,0 +1,162 @@
+/**
+ * Fetches all proposals in parallel, and formats them to be displayed as a table.
+ */
+async function getProposals (moloch) {
+  const queueLength = (await moloch.getProposalQueueLength()).toNumber()
+  const currentPeriod = (await moloch.getCurrentPeriod()).toNumber()
+
+  return Promise.all(
+    Array.from({ length: queueLength }).map((_, index) =>
+      moloch.proposalQueue(index).then(proposal =>
+        formatSimpleProposal(proposal, currentPeriod, index)
+      )
+    )
+  )
+}
+
+/**
+ * Fetches a given proposal by Id, and formats its fields to be displayed as a human-readable JSON.
+ */
+async function getDetailedProposal (moloch, proposalIndex) {
+  const queueLength = (await moloch.getProposalQueueLength()).toNumber()
+
+  if (proposalIndex >= queueLength) {
+    console.error(`A proposal with Id: ${proposalIndex} doesn't exist, please try again with an Id in the range [0..${queueLength - 1}]`)
+    return
+  }
+
+  const rawProposal = await moloch.proposalQueue(proposalIndex)
+  const currentPeriod = (await moloch.getCurrentPeriod()).toNumber()
+
+  const { title, description } = extractDetails(rawProposal)
+
+  return {
+    id: proposalIndex,
+    title,
+    description,
+    proposer: rawProposal.proposer,
+    applicant: rawProposal.applicant,
+    status: determineProposalStatus(rawProposal, currentPeriod),
+    sharesRequested: rawProposal.sharesRequested,
+    startingPeriod: rawProposal.startingPeriod,
+    yesVotes: rawProposal.yesVotes,
+    noVotes: rawProposal.noVotes,
+    tokenTribute: rawProposal.tokenTribute,
+    maxTotalSharesAtYesVote: rawProposal.maxTotalSharesAtYesVote
+  }
+}
+
+/**
+ * Formats a proposal to only contain ID, Status and Title.
+ */
+function formatSimpleProposal (proposal, currentPeriod, index) {
+  const { title } = extractDetails(proposal)
+
+  return {
+    ID: index,
+    Status: determineProposalStatus(proposal, currentPeriod),
+    Title: trimTitle(title)
+  }
+}
+
+/**
+ * Formats the raw `proposal.details` into nicely formatted title and description.
+ */
+function extractDetails (proposal) {
+  let title, description
+
+  try {
+    const jsonDetails = JSON.parse(proposal.details)
+
+    if (typeof jsonDetails !== 'object' || jsonDetails.title === undefined || jsonDetails.description === undefined) {
+      throw new Error(`Proposal details is not a valid JSON object with properties "title" and "description": ${jsonDetails}`)
+    }
+
+    title = jsonDetails.title
+    description = jsonDetails.description
+  } catch (_) {
+    // Special case two proposals with invalid JSON payload
+    /* eslint-disable no-tabs */
+    if (proposal.details === '{	itle:Member Proposal: DCInvestor,description:https://paper.dropbox.com/doc/MGP3-ETH2.0-Test-Runner--AcFiUF_av4SF5CHOuS4qSH0WAg-DZu4VRgbP1LZeUimS1k3L}') {
+      title = 'Membership Proposal: DCInvestor'
+      description = 'https://paper.dropbox.com/doc/MGP3-ETH2.0-Test-Runner--AcFiUF_av4SF5CHOuS4qSH0WAg-DZu4VRgbP1LZeUimS1k3L'
+    } else if (proposal.details === '{title:Member Proposal: Anon,description:https://etherpad.net/p/anon_moloch_proposal}') {
+      title = 'Membership Proposal: Anon'
+      description = 'https://etherpad.net/p/anon_moloch_proposal'
+    } else {
+      title = proposal.details
+      description = 'N/A'
+    }
+  }
+
+  return { title, description }
+}
+
+/**
+ * Ensures the title is at most 60 characters long
+ */
+function trimTitle (title) {
+  return title.length > 60 ? title.split('').slice(0, 57).join('').concat('...') : title
+}
+
+// Below are all the functions needed to determine proposal status
+const VOTING_PERIOD_LENGTH = 35
+const GRACE_PERIOD_LENGTH = 35
+
+const ProposalStatus = {
+  Unknown: 'Unknown',
+  InQueue: 'In queue',
+  VotingPeriod: 'Voting period',
+  GracePeriod: 'Grace period',
+  Aborted: 'Aborted',
+  Passed: 'Passed',
+  Failed: 'Failed',
+  ReadyForProcessing: 'Ready for processing'
+}
+
+function inQueue (startingPeriod, currentPeriod) {
+  return currentPeriod < startingPeriod
+}
+
+function inGracePeriod (startingPeriod, currentPeriod) {
+  return currentPeriod > startingPeriod + VOTING_PERIOD_LENGTH &&
+    currentPeriod < startingPeriod + VOTING_PERIOD_LENGTH + GRACE_PERIOD_LENGTH
+}
+
+function inVotingPeriod (startingPeriod, currentPeriod) {
+  return currentPeriod >= startingPeriod && currentPeriod <= startingPeriod + VOTING_PERIOD_LENGTH
+}
+
+function passedVotingAndGrace (startingPeriod, currentPeriod) {
+  return currentPeriod > startingPeriod + VOTING_PERIOD_LENGTH + GRACE_PERIOD_LENGTH
+}
+
+function determineProposalStatus (proposal, currentPeriod) {
+  const startingPeriod = proposal.startingPeriod.toNumber()
+
+  let status
+  if (proposal.processed && proposal.aborted) {
+    status = ProposalStatus.Aborted
+  } else if (proposal.processed && proposal.didPass) {
+    status = ProposalStatus.Passed
+  } else if (proposal.processed && !proposal.didPass) {
+    status = ProposalStatus.Failed
+  } else if (inGracePeriod(startingPeriod, currentPeriod)) {
+    status = ProposalStatus.GracePeriod
+  } else if (inVotingPeriod(startingPeriod, currentPeriod)) {
+    status = ProposalStatus.VotingPeriod
+  } else if (inQueue(startingPeriod, currentPeriod)) {
+    status = ProposalStatus.InQueue
+  } else if (passedVotingAndGrace(startingPeriod, currentPeriod)) {
+    status = ProposalStatus.ReadyForProcessing
+  } else {
+    status = ProposalStatus.Unknown
+  }
+
+  return status
+}
+
+module.exports = {
+  getProposals,
+  getDetailedProposal
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -85,9 +85,9 @@ async function getFirstAccount () {
 }
 
 async function hasEnoughPoolShares (pool, owner, amount) {
-  const shares = await pool.donors(owner);
-  
-  return shares.gte(new BN(amount));
+  const shares = await pool.donors(owner)
+
+  return shares.gte(new BN(amount))
 }
 
 module.exports = {


### PR DESCRIPTION
Hey there @ameensol, I'm a member of @nomiclabs.

We noticed there was some missing functionality on the tasks side for it to be a complete application, so we added the following 2 tasks to read proposal data:

- `moloch-list-proposals` Get a simplified list of all the proposals
- `moloch-proposal-details --proposal-id` Get a detailed view of a proposal

Example usage:
```bash
npx buidler moloch-list-proposals --network mainnet

npx buidler moloch-proposal-details --proposal-id 75 --network mainnet
```