### PR TITLE
Update > to >= on collectTokens

### DIFF
--- a/contracts/Moloch.sol
+++ b/contracts/Moloch.sol
@@ -599,7 +599,7 @@ contract Moloch is ReentrancyGuard {
         // only collect if 1) there are tokens to collect 2) token is whitelisted 3) token has non-zero balance
         require(amountToCollect > 0, 'no tokens to collect');
         require(tokenWhitelist[token], 'token to collect must be whitelisted');
-        require(userTokenBalances[GUILD][token] > 0, 'token to collect must have non-zero guild bank balance');
+        require(userTokenBalances[GUILD][token] >= 0, 'token to collect must have non-zero guild bank balance');
         
         unsafeAddToBalance(GUILD, token, amountToCollect);
         emit TokensCollected(token, amountToCollect);


### PR DESCRIPTION
As long as there's no security risk, this would allow collectTokens to work in the following example:

One sends and ERC20 straight to the DAO's contract.
DAO wants to use the ERC20, so can whitelist the token through a proposal.
IF passes, any DAO member can collectTokens to sync the balance.

Currently, due to the `>` instead of `>=` a tribute must be offered through a proposal first to raise the balance over `0` in order to collectTokens.