### PR TITLE
Document optimizer requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ To compute their code coverage run `npm run coverage`.
 
 This project includes Buidler tasks for deploying and using DAOs and Pools.
 
+Note that if you are using the Moloch contract outside of this repo, it must be compiled with the solidity optimizer enabled (runs=200), or attempting to deploy it will result in an out-of-gas exception.
+
 #### Deploying a new DAO
 
 Follow this instructions to deploy a new DAO:


### PR DESCRIPTION
This was mentioned in #59, but there is nothing about it in the readme at the moment. It's particularly deceptive because the un-optimized bytecode is greater than the [evm](https://github.com/ethereum/go-ethereum/blob/d2d3166f35b7cdaa63c54503bfccd4c808564f18/core/vm/evm.go#L422) [maximum](https://github.com/ethereum/go-ethereum/blob/d2d3166f35b7cdaa63c54503bfccd4c808564f18/params/protocol_params.go#L112), so you will get an out-of-gas error regardless of the block gas limit.