### PR TITLE
remove only and add Token

### DIFF
--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.2;
+
+import "./ERC20.sol";
+
+
+contract Token is ERC20 {
+    constructor(uint256 supply) public {
+        _mint(msg.sender, supply);
+    }
+}

--- a/test/molochV2-multitoken.test.js
+++ b/test/molochV2-multitoken.test.js
@@ -1454,7 +1454,7 @@ contract('Moloch', ([creator, summoner, applicant1, applicant2, processor, deleg
       }
     })
 
-    it.only('can still ragequit and withdraw', async function() {
+    it('can still ragequit and withdraw', async function() {
       this.timeout(1200000)
 
       const memberData = await moloch.members(proposal1.applicant)


### PR DESCRIPTION
There are still some tests that fail:

```
    token count limit - add tokens during operation
      1) "before each" hook for "proposal to add another token fails when maximum reached"
    guild bank token limit
      2) "before each" hook for "submitting new tribute tokens after max is reached fails"

            3) require fail - too many tokens
```